### PR TITLE
PYTRAJ notebook: fix typos for mpi example + add comment about segfault

### DIFF
--- a/note-books/parallel/rmsd_mpi.ipynb
+++ b/note-books/parallel/rmsd_mpi.ipynb
@@ -16,7 +16,7 @@
    "outputs": [],
    "source": [
     "# require: mpi4py, python2.7\n",
-    "# mpi4py does not work with python3.4 yes AFAIK"
+    "# mpi4py does not work with python3.4 yet (AFAIK: installed mpi4py from conda)"
    ]
   },
   {

--- a/note-books/parallel/rmsd_mpi_example.py
+++ b/note-books/parallel/rmsd_mpi_example.py
@@ -39,6 +39,8 @@ if rank != 0:
     ref = Frame()
     ref.append_xyz(ref_xyz)
 
+# got segmentation fault if not making a copy of ref
+# TODO : check MPI stuff
 _ref = ref.copy()
 
 def rmsd_mpi(traj, _ref):


### PR DESCRIPTION
Link for notebook:
http://nbviewer.ipython.org/github/pytraj/pytraj/blob/master/note-books/parallel/rmsd_mpi.ipynb