### PR TITLE
PYTRAJ: speed test for slicing: 10000 times faster

### DIFF
--- a/note-books/speed_test_2_trajs.ipynb
+++ b/note-books/speed_test_2_trajs.ipynb
@@ -87,12 +87,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.36 s, sys: 756 ms, total: 3.12 s\n",
-      "Wall time: 3.11 s\n",
-      "CPU times: user 2.25 s, sys: 418 ms, total: 2.67 s\n",
-      "Wall time: 2.67 s\n",
-      "CPU times: user 179 ms, sys: 40 ms, total: 219 ms\n",
-      "Wall time: 218 ms\n"
+      "CPU times: user 2.43 s, sys: 839 ms, total: 3.26 s\n",
+      "Wall time: 4.18 s\n",
+      "CPU times: user 2.24 s, sys: 428 ms, total: 2.66 s\n",
+      "Wall time: 2.68 s\n",
+      "CPU times: user 207 ms, sys: 12 ms, total: 219 ms\n",
+      "Wall time: 219 ms\n"
      ]
     }
    ],
@@ -135,9 +135,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 787 µs per loop\n",
+      "1000 loops, best of 3: 844 µs per loop\n",
       "1 loops, best of 3: 248 ms per loop\n",
-      "1 loops, best of 3: 1.04 s per loop\n"
+      "1 loops, best of 3: 1.02 s per loop\n"
      ]
     }
    ],
@@ -161,21 +161,21 @@
      "output_type": "stream",
      "text": [
       "iter FrameArray\n",
-      "1000 loops, best of 3: 1.17 ms per loop\n",
+      "1000 loops, best of 3: 836 µs per loop\n",
       "iter FrameArray and create numpy memoryview for Frame coords: use `asarray`\n",
-      "10 loops, best of 3: 29.5 ms per loop\n",
+      "10 loops, best of 3: 31.4 ms per loop\n",
       "iter FrameArray and create numpy array without memoryview for Frame coords: use `array`\n",
-      "1 loops, best of 3: 214 ms per loop\n",
+      "1 loops, best of 3: 218 ms per loop\n",
       "\n",
       "iter Traj (numpy version)\n",
-      "1 loops, best of 3: 246 ms per loop\n",
+      "1 loops, best of 3: 247 ms per loop\n",
       "iter Traj (numpy) and create numpy memoryview for Frame coords\n",
-      "1 loops, best of 3: 288 ms per loop\n",
+      "1 loops, best of 3: 289 ms per loop\n",
       "\n",
       "iter TrajReadOnly\n",
-      "1 loops, best of 3: 1.01 s per loop\n",
+      "1 loops, best of 3: 1.02 s per loop\n",
       "iter TrajReadOnly and create numpy memoryview for Frame coords\n",
-      "1 loops, best of 3: 1.11 s per loop\n"
+      "1 loops, best of 3: 1.1 s per loop\n"
      ]
     }
    ],
@@ -220,9 +220,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1000 loops, best of 3: 1.63 ms per loop\n",
-      "100 loops, best of 3: 4.25 ms per loop\n",
-      "100 loops, best of 3: 18.7 ms per loop\n"
+      "1000 loops, best of 3: 1.38 ms per loop\n",
+      "100 loops, best of 3: 2.98 ms per loop\n",
+      "100 loops, best of 3: 15.4 ms per loop\n"
      ]
     }
    ],
@@ -247,17 +247,18 @@
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {
-    "collapsed": false
+    "collapsed": false,
+    "scrolled": true
    },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 496 ms per loop\n",
-      "The slowest run took 44.06 times longer than the fastest. This could mean that an intermediate result is being cached \n",
-      "10000000 loops, best of 3: 113 ns per loop\n",
-      "1 loops, best of 3: 2.65 s per loop\n"
+      "1 loops, best of 3: 517 ms per loop\n",
+      "The slowest run took 34.66 times longer than the fastest. This could mean that an intermediate result is being cached \n",
+      "10000000 loops, best of 3: 115 ns per loop\n",
+      "1 loops, best of 3: 2.79 s per loop\n"
      ]
     }
    ],
@@ -275,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## calc_rmsd"
+    "## slicing"
    ]
   },
   {
@@ -284,15 +285,140 @@
    "metadata": {
     "collapsed": false
    },
+   "outputs": [],
+   "source": [
+    "import mdtraj as md\n",
+    "\n",
+    "top_name = \"../tests/data/nogit/remd/myparm.parm7\"\n",
+    "filename = \"../tests/data/nogit/remd/remd.x.000\"\n",
+    "m_top = md.load_prmtop(top_name)\n",
+    "m_traj = md.load_netcdf(filename, top=m_top)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 1.75 s per loop\n",
-      "1 loops, best of 3: 2.24 s per loop\n",
-      "1 loops, best of 3: 2.83 s per loop\n",
-      "1 loops, best of 3: 414 ms per loop\n"
+      "FrameArray\n",
+      "1 loops, best of 3: 315 ms per loop\n",
+      "api.Trajectory\n",
+      "The slowest run took 4.41 times longer than the fastest. This could mean that an intermediate result is being cached \n",
+      "100000 loops, best of 3: 17.9 µs per loop\n",
+      "TrajReadOnly\n",
+      "1 loops, best of 3: 486 ms per loop\n",
+      "mdtraj\n",
+      "10 loops, best of 3: 189 ms per loop\n",
+      "<FrameArray with 200 frames, 17443 atoms/frame>\n",
+      "           \n",
+      "Trajectory with 200 frames, 17443 atoms\n",
+      "<FrameArray with 200 frames, 17443 atoms/frame>\n",
+      "           \n",
+      "<mdtraj.Trajectory with 200 frames, 17443 atoms, 5666 residues, and unitcells>\n"
+     ]
+    }
+   ],
+   "source": [
+    "## slicing\n",
+    "\n",
+    "s = slice(0, 1000, 5)\n",
+    "print(\"FrameArray\")\n",
+    "%timeit fa[s]\n",
+    "\n",
+    "print (\"api.Trajectory\")\n",
+    "%timeit traj[s]\n",
+    "\n",
+    "print (\"TrajReadOnly\")\n",
+    "%timeit trajread[s]\n",
+    "\n",
+    "print (\"mdtraj\")\n",
+    "%timeit m_traj[s]\n",
+    "\n",
+    "# make sure we sliced the trajs correctly\n",
+    "print (fa[s])\n",
+    "print (traj[s])\n",
+    "print (trajread[s])\n",
+    "print (m_traj[s])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## asignment"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "FrameArray\n",
+      "1 loops, best of 3: 284 ms per loop\n",
+      "api.Trajectory: frame iteration\n",
+      "1 loops, best of 3: 529 ms per loop\n",
+      "api.Trajectory: numpy\n",
+      "1 loops, best of 3: 236 ms per loop\n",
+      "TrajReadOnly\n",
+      "1 loops, best of 3: 1.3 s per loop\n",
+      "mdtraj\n",
+      "1 loops, best of 3: 213 ms per loop\n"
+     ]
+    }
+   ],
+   "source": [
+    "xyz = traj.xyz.copy()\n",
+    "\n",
+    "print(\"FrameArray\")\n",
+    "%timeit for i, frame in enumerate(fa): frame[:] = xyz[i]\n",
+    "\n",
+    "print (\"api.Trajectory: frame iteration\")\n",
+    "%timeit for i, frame in enumerate(traj): frame[:] = xyz[i]\n",
+    "    \n",
+    "print (\"api.Trajectory: numpy\")\n",
+    "%timeit traj.xyz[:] = xyz\n",
+    "\n",
+    "print (\"TrajReadOnly\") # note: just for testing, xyz assigment does not change this TrajReadOnly's coords\n",
+    "%timeit for i, frame in enumerate(trajread): frame[:] = xyz[i]\n",
+    "\n",
+    "print (\"mdtraj\")\n",
+    "%timeit m_traj.xyz[:] = xyz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## calc_rmsd"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1 loops, best of 3: 1.09 s per loop\n",
+      "1 loops, best of 3: 1.58 s per loop\n",
+      "1 loops, best of 3: 2.1 s per loop\n",
+      "1 loops, best of 3: 386 ms per loop\n"
      ]
     }
    ],
@@ -317,7 +443,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 14,
    "metadata": {
     "collapsed": false
    },
@@ -326,9 +452,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1 loops, best of 3: 310 ms per loop\n",
-      "1 loops, best of 3: 910 ms per loop\n",
-      "1 loops, best of 3: 1.26 s per loop\n"
+      "1 loops, best of 3: 292 ms per loop\n",
+      "1 loops, best of 3: 887 ms per loop\n",
+      "1 loops, best of 3: 1.23 s per loop\n"
      ]
     }
    ],


### PR DESCRIPTION
1000 frames, >17K atoms,

(traj[0:1000:5])

FrameArray
1 loops, best of 3: 315 ms per loop

api.Trajectory <<-- superfast. numpy is rock.
The slowest run took 4.41 times longer than the fastest. This could mean that an intermediate result is being cached
100000 loops, best of 3: 17.9 µs per loop <<--- 20K times faster than FrameArray, 10K times faster than mdtraj

TrajReadOnly
1 loops, best of 3: 486 ms per loop

mdtraj
10 loops, best of 3: 189 ms per loop