### PR TITLE
PYTRAJ: avoid load/reload/reload AmberParm

### DIFF
--- a/note-books/energy_decomposition.ipynb
+++ b/note-books/energy_decomposition.ipynb
@@ -356,7 +356,7 @@
     }
    ],
    "source": [
-    "# just care about some 'minial' output?\n",
+    "# just care about some 'minimal' output?\n",
     "energies = pyca.energy_decomposition (traj, dtype='dataset', mode='minimal')\n",
     "energies # require pandas to have pretty print (but don't need pandas for getting raw data at all)"
    ]


### PR DESCRIPTION
with sander.setup(parm, ...), `ParmEd` try to save to file and let
`sander` reload. In original verion in pytraj, we load from file to
AmberParm object. I made change by letting `sander` directly load from
file.

anyway, the interface does not change.
pyca.energy_decomposition(traj, parm=None)
    parm: is optional, could be a filename, a AmberParm object from
`chemistry`. If `parm` is None, `pytraj` will look at `traj.top.filename`